### PR TITLE
Use optional chaining for checking type property

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -13,9 +13,9 @@ export class Table extends React.PureComponent<TableProps> {
         let tableBody: JSX.Element = null;
 
         React.Children.forEach(this.props.children, (c: any) => {
-            if (c.type === TableHeader) {
+            if (c?.type === TableHeader) {
                 tableHeader = c;
-            } else if (c.type === TableBody) {
+            } else if (c?.type === TableBody) {
                 tableBody = React.cloneElement(c, {
                     data: c.props.data ?? this.props.data ?? []
                 });

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -16,10 +16,13 @@ export class Table extends React.PureComponent<TableProps> {
             if (c?.type === TableHeader) {
                 tableHeader = c;
             } else if (c?.type === TableBody) {
-                tableBody = React.cloneElement(c, {
-                    data: c.props.data ?? this.props.data ?? []
-                });
+                tableBody = c;
             }
+        });
+
+        tableBody = React.cloneElement(tableBody, {
+            data: tableBody.props.data ?? this.props.data ?? [],
+            renderTopBorder: !tableHeader
         });
 
         return (

--- a/src/TableBody.tsx
+++ b/src/TableBody.tsx
@@ -9,10 +9,17 @@ export interface TableBodyProps extends TableRowProps {
     data?: any[];
 }
 
+// This interface adds a flag to indicate if we should render the top border,
+// thus allowing us to render it in the event that no
+// header rows were present in the table.
+interface InternalBodyProps extends TableBodyProps {
+    renderTopBorder?: boolean
+}
+
 /**
  * This component displays the data as {@see TableRow}s.
  */
-export class TableBody extends React.PureComponent<TableBodyProps> {
+export class TableBody extends React.PureComponent<InternalBodyProps> {
     render() {
         const rowCells: any[] = React.Children.toArray(this.props.children);
         const {includeLeftBorder, includeBottomBorder, includeRightBorder} = getDefaultBorderIncludes(this.props);
@@ -27,7 +34,7 @@ export class TableBody extends React.PureComponent<TableBodyProps> {
                     includeLeftBorder={includeLeftBorder}
                     includeBottomBorder={includeBottomBorder}
                     includeRightBorder={includeRightBorder}
-                    includeTopBorder={false}
+                    includeTopBorder={this.props.renderTopBorder ?? false}
                 >
                     {rowCells}
                 </TableRow>


### PR DESCRIPTION
At present, the `Table` component will throw an error if it has a `null` or `undefined` child, due to the property access I've altered. By using optional chaining, this should no longer cause an issue.

I ran into this when I used an optional boolean argument to conditionally render a header. Not having a header also causes an issue with rendering the table's top border, so I also tweaked the rendering of TableBody to mitigate that.