### PR TITLE
Inline ts into sourcemaps to avoid error referenceing non existant src/*.ts file

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     ],
     "module": "commonjs",
     "sourceMap": true,
+    "inlineSources": true,
     "jsx": "react",
     "target": "es5",
     "outDir": "./lib",


### PR DESCRIPTION
This PR aims to get rid of warnings like

```
WARNING in ./node_modules/@david.kucsai/react-pdf-table/lib/index.js
Module Warning (from ./node_modules/source-map-loader/dist/cjs.js):
Failed to parse source map from '/xxx/node_modules/@david.kucsai/react-pdf-table/src/index.ts' file: Error: ENOENT: no such file or directory, open '/xxx/node_modules/@david.kucsai/react-pdf-table/src/index.ts'
```

when building a project using this library.