### PR TITLE
Add row zebra styling

### DIFF
--- a/lib/src/Table.d.ts
+++ b/lib/src/Table.d.ts
@@ -1,6 +1,9 @@
 import * as React from "react";
 interface TableProps {
     data?: any[];
+    zebra?: boolean;
+    evenRowColor?: string;
+    oddRowColor?: string;
 }
 export declare class Table extends React.PureComponent<TableProps> {
     render(): JSX.Element;

--- a/lib/src/TableBody.d.ts
+++ b/lib/src/TableBody.d.ts
@@ -2,7 +2,12 @@ import { TableRowProps } from "./TableRow";
 import * as React from "react";
 export interface TableBodyProps extends TableRowProps {
     data?: any[];
+    zebra?: boolean;
 }
-export declare class TableBody extends React.PureComponent<TableBodyProps> {
+interface InternalBodyProps extends TableBodyProps {
+    renderTopBorder?: boolean;
+}
+export declare class TableBody extends React.PureComponent<InternalBodyProps> {
     render(): JSX.Element[];
 }
+export {};

--- a/lib/src/TableRow.d.ts
+++ b/lib/src/TableRow.d.ts
@@ -5,6 +5,10 @@ export interface TableRowProps extends TableBorder {
     fontSize?: number | string;
     textAlign?: "left" | "center" | "right";
     data?: any;
+    zebra?: boolean;
+    even?: boolean;
+    evenRowColor?: string;
+    oddRowColor?: string;
 }
 export declare class TableRow extends React.PureComponent<Partial<TableBodyProps>> {
     render(): JSX.Element;

--- a/lib/stories/components/story/ZebraTable.d.ts
+++ b/lib/stories/components/story/ZebraTable.d.ts
@@ -1,0 +1,12 @@
+import * as React from "react";
+import { HumanRow } from "../../data/Humans";
+interface ZebraTableHeaderState {
+    data: HumanRow[];
+}
+export declare class ZebraTable extends React.Component<{}, ZebraTableHeaderState> {
+    state: {
+        data: HumanRow[];
+    };
+    render(): JSX.Element;
+}
+export {};

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -5,6 +5,9 @@ import {View} from "@react-pdf/renderer";
 
 interface TableProps {
     data?: any[];
+    zebra?: boolean;
+    evenRowColor?: string;
+    oddRowColor?: string;
 }
 
 export class Table extends React.PureComponent<TableProps> {
@@ -22,7 +25,10 @@ export class Table extends React.PureComponent<TableProps> {
 
         tableBody = React.cloneElement(tableBody, {
             data: tableBody.props.data ?? this.props.data ?? [],
-            renderTopBorder: !tableHeader
+            renderTopBorder: !tableHeader,
+            zebra: tableBody.props.zebra ?? this.props.zebra ?? false,
+            evenRowColor: tableBody.props.evenRowColor ?? this.props.evenRowColor ?? '',
+            oddRowColor: tableBody.props.oddRowColor ?? this.props.oddRowColor ?? '',
         });
 
         return (

--- a/src/TableBody.tsx
+++ b/src/TableBody.tsx
@@ -7,6 +7,7 @@ export interface TableBodyProps extends TableRowProps {
      * The data associated with the table.
      */
     data?: any[];
+    zebra?: boolean;
 }
 
 // This interface adds a flag to indicate if we should render the top border,
@@ -30,6 +31,7 @@ export class TableBody extends React.PureComponent<InternalBodyProps> {
                 <TableRow
                     {...this.props}
                     key={rowIndex}
+                    even={rowIndex%2===0}
                     data={data}
                     includeLeftBorder={includeLeftBorder}
                     includeBottomBorder={includeBottomBorder}

--- a/src/TableRow.tsx
+++ b/src/TableRow.tsx
@@ -20,6 +20,26 @@ export interface TableRowProps extends TableBorder {
      * Any data associated, relevant if the parent is a {@see DataTableCell}.
      */
     data?: any;
+
+    /**
+     * Whether rows have alternating styles
+     */
+    zebra?: boolean;
+
+    /**
+     * Whether this row is even (true) or odd (false)
+     */
+    even?: boolean;
+
+    /**
+     * Specify the color of even rows
+     */
+    evenRowColor?: string;
+
+    /**
+     * Specify the color of odd rows
+     */
+    oddRowColor?: string;
 }
 
 /**
@@ -41,6 +61,8 @@ export class TableRow extends React.PureComponent<Partial<TableBodyProps>> {
 
         const weightingsPerNotSpecified = Math.ceil(remainingWeighting / (rowCells.length - numberOfWeightingsDefined));
 
+        const rowColor = ((this.props.zebra || this.props.evenRowColor) && this.props.even) ? this.props.evenRowColor || 'lightgray' : this.props.oddRowColor || '';
+
         return (
             <View
                 // @ts-ignore
@@ -52,7 +74,8 @@ export class TableRow extends React.PureComponent<Partial<TableBodyProps>> {
                     width: "100%",
                     display: "flex",
                     flexDirection: "row",
-                    justifyContent: "stretch"
+                    justifyContent: "space-between",
+                    backgroundColor: rowColor,
                 }}
             >
                 {

--- a/stories/components/story/ZebraTable.tsx
+++ b/stories/components/story/ZebraTable.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import {DataTableCell, Table, TableBody, TableCell, TableHeader} from "../../../src";
+import {PdfContainer} from "../PdfContainer";
+import {generateRandomData, HumanRow} from "../../data/Humans";
+
+interface ZebraTableHeaderState {
+    data: HumanRow[];
+}
+
+export class ZebraTable extends React.Component<{}, ZebraTableHeaderState> {
+    state = {
+        data: generateRandomData(20)
+    };
+
+    render() {
+        return (
+            <PdfContainer>
+                <Table
+                    data={this.state.data}
+                >
+                    <TableHeader>
+                        <TableCell>
+                            First Name
+                        </TableCell>
+                        <TableCell>
+                            Last Name
+                        </TableCell>
+                        <TableCell>
+                            DOB
+                        </TableCell>
+                        <TableCell>
+                            Country
+                        </TableCell>
+                        <TableCell>
+                            Phone Number
+                        </TableCell>
+                    </TableHeader>
+                    <TableBody evenRowColor="lightgray">
+                        <DataTableCell getContent={(r) => r.firstName}/>
+                        <DataTableCell getContent={(r) => r.lastName}/>
+                        <DataTableCell getContent={(r) => r.dob.toLocaleString()}/>
+                        <DataTableCell getContent={(r) => r.country}/>
+                        <DataTableCell getContent={(r) => r.phoneNumber}/>
+                    </TableBody>
+                </Table>
+            </PdfContainer>
+        )
+    }
+}

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -8,6 +8,7 @@ import Introduction from "./components/Introduction";
 import {SimpleTable} from "./components/story/SimpleTable";
 import {SimpleTableWithWeighting} from "./components/story/SimpleTableWithWeighting";
 import {NestedTables} from "./components/story/NestedTables";
+import {ZebraTable} from "./components/story/ZebraTable";
 
 storiesOf("Welcome", module).add("to react-pdf-table", () => <Introduction/>);
 
@@ -17,3 +18,4 @@ tableStories.addDecorator(withKnobs);
 tableStories.add("Simple Table", () => (<SimpleTable/>));
 tableStories.add("Simple Table with Weighting", () => (<SimpleTableWithWeighting/>));
 tableStories.add("Nested Tables", () => (<NestedTables/>));
+tableStories.add("Zebra Table", () => (<ZebraTable/>));


### PR DESCRIPTION
Adds row styling to allow alternating row colors.  New props on `Table` or `TableBody` are `zebra`, `evenRowColor`, and `oddRowColor`. 

To default alternating colors, simply add the `zebra` prop to `Table` or `TableBody`, or add `evenRowColor` with the desired color value (`lightgray`, `#cccccc`, `red`, etc.)