### PR TITLE
Support variables in TableCell

### DIFF
--- a/src/TableCell.tsx
+++ b/src/TableCell.tsx
@@ -71,6 +71,10 @@ export class TableCell extends React.PureComponent<TableCellProps> {
             content = (
                 <Text>{this.props.children.toString()}</Text>
             );
+        } elseif (Array.isArray(this.props.children) {
+            content = (
+                <Text>{this.props.children.join('')}</Text>   
+            );          
         } else {
             content = this.props.children;
         }


### PR DESCRIPTION
Thanks for the library.

Currently using variables in children of `<TableCell>` results in an error (`node.style` is not defined) e.g. 
```javascript
<TableCell>{variable}</TableCell>
```

This should fix that