### PR TITLE
Add new react, react-dom & @react-pdf/renderer dependency options.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
   "author": "David Kucsai",
   "license": "MIT",
   "peerDependencies": {
-    "@react-pdf/renderer": "^1.6.8",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6"
+    "@react-pdf/renderer": "^1.6.8 || ^2.0.0",
+    "react": "^16.8.6 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@react-pdf/renderer": "^1.6.8",


### PR DESCRIPTION
This fixes the issue https://github.com/dmk99/react-pdf-table/issues/45
`npm install` gives a warning without these peer dependency alternatives, when the react or react-dom or @react-pdf/renderer are incompatible with the dependencies in the root.

For example, let's suppose that you have `"@react-pdf/renderer": "^2.2.0"` as a dependency in your React project, with a React version of 18.0.0 for example. `npm install` will fail without additional flags such as `--force` or `--legacy-peer-deps`