### PR TITLE
Add option to disable wrapping on table cells

### DIFF
--- a/src/TableCell.tsx
+++ b/src/TableCell.tsx
@@ -54,6 +54,11 @@ export interface TableCellProps extends TableBorder {
      * The font-size to apply to the cell.
      */
     fontSize?: number | string;
+
+    /**
+     * Whether to use react-pdf's automatic wrapping for the cell content. If not defined it will be true.
+     */
+    wrap?: boolean;
 }
 
 /**
@@ -95,7 +100,7 @@ export class TableCell extends React.PureComponent<TableCellProps> {
         return (
             <View
                 style={mergedStyles}
-                wrap={true}
+                wrap={this.props.wrap ?? true}
             >
                 {content}
             </View>


### PR DESCRIPTION
As described in #49 . We have been internally testing this change and it seems to work quite well. 

This doesn't break any existing code, since the default is still true.